### PR TITLE
Add a test for PR 23954

### DIFF
--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -600,6 +600,13 @@ class UDFTests(ReusedSQLTestCase):
             result = sql("select i from values(0L) as data(i) where i in (select id from v)")
             self.assertEqual(result.collect(), [Row(i=0)])
 
+    def test_udf_globals_not_overwritten(self):
+        @udf('string')
+        def f():
+            assert "itertools" not in str(map)
+
+        self.spark.range(1).select(f()).collect()
+
 
 class UDFInitializationTests(unittest.TestCase):
     def tearDown(self):


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds a test in PR 23954.

## How was this patch tested?

Tested via `./run-tests --testnames 'pyspark.sql.tests.test_udf UDFTests.test_udf_globals_not_overwritten'`
